### PR TITLE
Use cargo install instead of copying binary from build folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ License section. Then the README.md will be overwritten. So there **SHOULD** be 
 Download the Sourcecode, then in the directory execute in terminal:
 
 ```bash
-cargo build --release
-#unix
-cp $(pwd)/target/release/license-me /bin/
-#windows
+cargo install --path .
+```
 
-#copy the "license-me.exe" from .../target/release/ to anywhere you like
+### Install Using Cargo
+
+```bash
+cargo install --git https://github.com/frequency403/license-me.git
 ```
 ### Download pre-built binary's
 


### PR DESCRIPTION
Hi there, came from the reddit post on [r/rust.](https://www.reddit.com/r/rust/comments/11rs61a/one_of_my_first_rust_projects_tell_me_what_you/). I loved reading all the feedback and I also liked that you've brought to the table. There was just one thing that caught my eye, when reading the README. The way you chose to add the executable to a place where it would be recognized. Although it's perfectly valid to do it the way you did, I just wanted to show that cargo has a built in features for this, and that cloning the repo isn't necessary when using this method.

Edit:

A comparison:

```bash
cargo install --path .

# or

cargo install --git https://github.com/frequency403/license-me
```
vs
```bash
cargo build --release
#unix
cp $(pwd)/target/release/license-me /bin/
#windows

#copy the "license-me.exe" from .../target/release/ to anywhere you like
```